### PR TITLE
optional path on bindToState

### DIFF
--- a/src/BindToMixin.ts
+++ b/src/BindToMixin.ts
@@ -334,7 +334,7 @@ module DataBinding{
          * @param converterParams - parameters used by converter
          * @returns {DataBinding.PathObjectBinding}
          */
-        public bindToState(key, path,converter?:IValueConverter,converterParams?):IPathObjectBinding {
+        public bindToState(key, path?,converter?:IValueConverter,converterParams?):IPathObjectBinding {
             return new PathObjectBinding(
                 this["state"][key],
                 path,


### PR DESCRIPTION
Hi,

Just turned the path parameter optional as it seems to be in PathObjectBinding. Everything works fine just passing the key parameter.

Is there a way to use your lib with typescript? Maybe generate a .d.ts file?
I actually copy/paste BindToMixin.ts to my project.
